### PR TITLE
Change PHP_MIRROR to us2.php.net

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ export
 
 PHP ?= 5.6
 JOBS ?= 2
-PHP_MIRROR ?= http://us1.php.net/distributions/
+PHP_MIRROR ?= http://us2.php.net/distributions/
 TMPDIR ?= /tmp
 
 tmpnam := $(TMPDIR)/php-$(PHP)-$(shell env |grep -E '^with_|^enable_' | tr -c '[a-zA-Z_]' -)


### PR DESCRIPTION
us1.php.net was removed a while ago.
Fixes
> $ make -f travis/pecl/Makefile php
> 
> mkdir -p /home/travis/job-20.3/src
> 
> printf "master\tmaster\tgit clone --depth 1 -b master https://github.com/php/php-src php-master && cd php-master && ./buildconf\n" >/home/travis/job-20.3/src/releases.tsv
> 
> curl -Ss "http://php.net/releases/index.php?json&version=7&max=-1" | travis/pecl//php-version-url-dist.php >>/home/travis/job-20.3/src/releases.tsv
> 
> curl -Ss "http://php.net/releases/index.php?json&version=5&max=-1" | travis/pecl//php-version-url-dist.php >>/home/travis/job-20.3/src/releases.tsv
> 
> curl -Ss "http://qa.php.net/api.php?type=qa-releases&format=json"  | travis/pecl//php-version-url-qa.php   >>/home/travis/job-20.3/src/releases.tsv
> 
> cd /home/travis/job-20.3/src && awk -F "\t" '/^5.6\t/{exit system($3)}' </home/travis/job-20.3/src/releases.tsv
> 
> curl: (6) Could not resolve host: us1.php.net